### PR TITLE
chore: drop support for Node.js 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ language: node_js
 node_js:
   - v5
   - v4
-  - '0.12'
-  - '0.10'
 after_script:
   - 'npm run coveralls'


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 0.10